### PR TITLE
Fix lengthKind 'implicit' on all complex type elements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bsp
-target
+target/
 *.swp
 tags
+.idea/

--- a/src/main/resources/com/owlcyberdefense/ntp/xsd/baseFormat.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/ntp/xsd/baseFormat.dfdl.xsd
@@ -18,7 +18,7 @@
                    byteOrder="bigEndian"
                    bitOrder="mostSignificantBitFirst"
                    encoding="ASCII"
-				   lengthKind='explicit'
+				   lengthKind='implicit'
 				   lengthUnits='bits'
                    alignmentUnits="bits"
                    alignment="1"

--- a/src/main/resources/com/owlcyberdefense/ntp/xsd/ntp.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/ntp/xsd/ntp.dfdl.xsd
@@ -18,7 +18,7 @@
 		</appinfo>
 	</annotation>
 
-	<element name="Ntp" type="ntp:ntp" dfdl:lengthKind='implicit' />
+	<element name="Ntp" type="ntp:ntp" />
 
 	<complexType name="ntp">
 		<sequence>
@@ -29,13 +29,13 @@
 			<element name="Stratum" type="ntp:Stratum"/>
 			<element name="Poll" type="ntp:Poll"/>
 			<element name="Precision" type="ntp:Precision"/>
-			<element name="RootDelay" type="ntp:ntpShortTime" dfdl:lengthKind='implicit'/>
-			<element name="RootDispersion" type="ntp:ntpShortTime" dfdl:lengthKind='implicit'/>
+			<element name="RootDelay" type="ntp:ntpShortTime"/>
+			<element name="RootDispersion" type="ntp:ntpShortTime"/>
 			<element name="ReferenceID" type="ntp:RefId"/>
-			<element name="ReferenceTimeStamp" type="ntp:ntpTimeStamp" dfdl:lengthKind='implicit'/>
-			<element name="OriginTimeStamp" type="ntp:ntpTimeStamp" dfdl:lengthKind='implicit'/>
-			<element name="ReceiveTimeStamp" type="ntp:ntpTimeStamp" dfdl:lengthKind='implicit'/>
-			<element name="TransmitTimeStamp" type="ntp:ntpTimeStamp" dfdl:lengthKind='implicit'/>
+			<element name="ReferenceTimeStamp" type="ntp:ntpTimeStamp"/>
+			<element name="OriginTimeStamp" type="ntp:ntpTimeStamp"/>
+			<element name="ReceiveTimeStamp" type="ntp:ntpTimeStamp"/>
+			<element name="TransmitTimeStamp" type="ntp:ntpTimeStamp"/>
 
 		</sequence>
 	</complexType>

--- a/src/main/resources/com/owlcyberdefense/ntp/xsd/types.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/ntp/xsd/types.dfdl.xsd
@@ -13,9 +13,24 @@
 
 	<annotation>
 		<appinfo source="http://www.ogf.org/dfdl/">
-			<dfdl:format ref="ntp:baseFormat" lengthKind="explicit"/>
+			<dfdl:format ref="ntp:baseFormat"/>
 		</appinfo>
 	</annotation>
+
+	<!--
+	Derive all explicit length integer types from these
+	base types.
+
+	Enables the overall schema to be lengthKind 'implicit' which
+	is needed for all the complex type elements.
+	-->
+	<simpleType name="sint" dfdl:lengthKind="explicit">
+		<restriction base="xs:int"/>
+	</simpleType>
+
+	<simpleType name="uint" dfdl:lengthKind="explicit">
+		<restriction base="xs:unsignedInt"/>
+	</simpleType>
 
 	<!-- NTP Short Format
 		 The 32-bit short format is used in delay and dispersion
@@ -26,8 +41,8 @@
 	-->
 	<complexType name="ntpShortTime">
 		<sequence>
-			<xs:element name="seconds" type="xs:unsignedInt" dfdl:length="16"/>
-			<xs:element name="fraction" type="xs:int" dfdl:length="16"/>
+			<xs:element name="seconds" type="ntp:uint" dfdl:length="16"/>
+			<xs:element name="fraction" type="ntp:sint" dfdl:length="16"/>
 		</sequence>
 	</complexType>
 
@@ -39,10 +54,10 @@
 	<complexType name="ntpTimeStamp">
 		<xs:sequence>
 			<xs:element name="seconds"
-				type="xs:unsignedInt"
+				type="ntp:uint"
 				dfdl:length="32"/>
 			<xs:element name="fraction"
-				type="xs:int"
+				type="ntp:sint"
 				dfdl:length="32"/>
 		</xs:sequence>
 	</complexType>
@@ -58,38 +73,38 @@
 
   <complexType name="ntpDate">
 	  <sequence>
-		  <xs:element name="eraNumber" type="xs:int" dfdl:length="32"/>
-		  <xs:element name="eraOffset" type="xs:int" dfdl:length="32"/>
-		  <xs:element name="fraction" type="xs:int" dfdl:length="64"/>
+		  <xs:element name="eraNumber" type="ntp:sint" dfdl:length="32"/>
+		  <xs:element name="eraOffset" type="ntp:sint" dfdl:length="32"/>
+		  <xs:element name="fraction" type="ntp:sint" dfdl:length="64"/>
 	  </sequence>
   </complexType>
 
   <simpleType name="LI" dfdl:length="2">
-	  <restriction base="xs:unsignedByte"/>
+	  <restriction base="ntp:uint"/>
   </simpleType>
 
   <simpleType name="VN" dfdl:length="3">
-	  <restriction base="xs:unsignedByte"/>
+	  <restriction base="ntp:uint"/>
   </simpleType>
 
   <simpleType name="Mode" dfdl:length="3">
-	  <restriction base="xs:unsignedByte"/>
+	  <restriction base="ntp:uint"/>
   </simpleType>
 
   <simpleType name="Stratum" dfdl:length="8">
-	  <restriction base="xs:unsignedByte"/>
+	  <restriction base="ntp:uint"/>
   </simpleType>
 
   <simpleType name="Poll" dfdl:length="8">
-	  <restriction base="xs:unsignedByte"/>
+	  <restriction base="ntp:uint"/>
   </simpleType>
 
   <simpleType name="Precision" dfdl:length="8">
-	  <restriction base="xs:unsignedByte"/>
+	  <restriction base="ntp:uint"/>
   </simpleType>
 
   <simpleType name="RefId" dfdl:length="32">
-	  <restriction base="xs:int"/>
+	  <restriction base="ntp:sint"/>
   </simpleType>        
 
 </schema>

--- a/src/test/resources/com/owlcyberdefense/ntp/TestNtp.tdml
+++ b/src/test/resources/com/owlcyberdefense/ntp/TestNtp.tdml
@@ -19,6 +19,54 @@
     </infoset>
   </parserTestCase>
 
+  <parserTestCase name="test_all_ff_01" root="Ntp" model="com/owlcyberdefense/ntp/xsd/ntp.dfdl.xsd">
+    <document>
+      <documentPart type="byte"><![CDATA[
+                              ff ff ff ff ff ff
+ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+ff ff ff ff ff ff ff ff ff ff
+]]></documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ntp:Ntp xmlns:ntp="urn:ntp">
+          <LI>3</LI>
+          <VN>7</VN>
+          <Mode>7</Mode>
+          <Stratum>255</Stratum>
+          <Poll>255</Poll>
+          <Precision>255</Precision>
+          <RootDelay>
+            <seconds>65535</seconds>
+            <fraction>-1</fraction>
+          </RootDelay>
+          <RootDispersion>
+            <seconds>65535</seconds>
+            <fraction>-1</fraction>
+          </RootDispersion>
+          <ReferenceID>-1</ReferenceID>
+          <ReferenceTimeStamp>
+            <seconds>4294967295</seconds>
+            <fraction>-1</fraction>
+          </ReferenceTimeStamp>
+          <OriginTimeStamp>
+            <seconds>4294967295</seconds>
+            <fraction>-1</fraction>
+          </OriginTimeStamp>
+          <ReceiveTimeStamp>
+            <seconds>4294967295</seconds>
+            <fraction>-1</fraction>
+          </ReceiveTimeStamp>
+          <TransmitTimeStamp>
+            <seconds>4294967295</seconds>
+            <fraction>-1</fraction>
+          </TransmitTimeStamp>
+        </ntp:Ntp>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
   <!-- example hex data from pcap file ntp-only.pcap
   To make tests from these for comparsison with wireshark
 

--- a/src/test/scala/com/owlcyberdefense/ntp/TestNtp.scala
+++ b/src/test/scala/com/owlcyberdefense/ntp/TestNtp.scala
@@ -18,4 +18,6 @@ class TestNtp {
   import TestNtp._
 
   @Test def test_ntp_05(): Unit = { runner.runOneTest("test_ntp_05") }
+  @Test def test_all_ff_01(): Unit = { runner.runOneTest("test_all_ff_01") }
+
 }


### PR DESCRIPTION
Length kind 'implicit' is no longer needed. Default lengthKind is 'implicit'.
All explicit length things are derived from base types which use lengthKind 'explicit'.

Fixes Issue https://github.com/OpenDFDL/ntp/issues/7